### PR TITLE
♻️ refactor: "정렬 선택" 옵션에 렌더링 조건 추가

### DIFF
--- a/src/pages/AllProducts/index.jsx
+++ b/src/pages/AllProducts/index.jsx
@@ -11,6 +11,7 @@ const AllProducts = () => {
   const handleSelect = e => {
     setSelected(e.target.value);
   };
+  const [defaultOption, setDefaultOption] = useState(true);
 
   useEffect(() => {
     if (Selected && Selected === '이름순') {
@@ -25,10 +26,12 @@ const AllProducts = () => {
         }
       });
       setProducts(copy);
+      setDefaultOption(false);
     } else if (Selected && Selected === '한도순') {
       let copy = [...products];
       copy.sort((a, b) => b.supporterAmount - a.supporterAmount);
       setProducts(copy);
+      setDefaultOption(false);
     }
   }, [Selected]);
 
@@ -39,7 +42,7 @@ const AllProducts = () => {
           <S.Title>대출 검색</S.Title>
           <S.SelectDiv>
             <Form.Select size='sm' onChange={handleSelect}>
-              <option>정렬 선택</option>
+              {defaultOption && <option>정렬 선택</option>}
               <option>이름순</option>
               <option>한도순</option>
             </Form.Select>


### PR DESCRIPTION
## <img src='https://emojis.slackmojis.com/emojis/images/1643514558/5570/confused_dog.gif?1643514558' alt='개요' width=30px> 개요
기본 옵션은 첫 렌더링 때만 보이고 다른 옵션을 선택하면 사라기게 구현하고 싶어서 기본옵션에 렌더링 조건을 추가하였습니다.

## <img src='https://emojis.slackmojis.com/emojis/images/1643514738/7421/typingcat.gif?1643514738' alt='작업 사항' width=30px> 작업 사항
- [x] 정렬 버튼에 있는 `정렬 선택` 기본 옵션이 `이름순` 혹은 `한도순` 옵션을 클릭하면 안 보이게 하는 렌더링 조건 추가

## 이슈 번호
#34
