### PR TITLE
[feat][design]Entry/#69

### DIFF
--- a/src/components/layout/TheFooter/index.jsx
+++ b/src/components/layout/TheFooter/index.jsx
@@ -5,7 +5,7 @@ const TheFooter = () => {
   return (
     <S.TheFooter>
       <S.CustomLink to='/custom-products'>맞춤형 상품</S.CustomLink>
-      <S.CustomLink to='/all-products'>금융 상품</S.CustomLink>
+      <S.CustomLink to='/'>금융 상품</S.CustomLink>
       <S.CustomLink to='/wish-products'>찜해둔 상품</S.CustomLink>
     </S.TheFooter>
   );

--- a/src/pages/Entry/Index.jsx
+++ b/src/pages/Entry/Index.jsx
@@ -7,9 +7,11 @@ const Entry = () => {
   const navigate = useNavigate();
   return (
     <S.Container>
-      <S.Title>서비스 페이지입니다</S.Title>
-      <S.Button onClick={() => navigate('/sign-in')}>로그인</S.Button>
-      <S.Button onClick={() => navigate('/sign-up')}>회원가입</S.Button>
+      <S.Inner>
+        <S.Title>서비스 페이지입니다</S.Title>
+        <S.Button onClick={() => navigate('/sign-in')}>로그인</S.Button>
+        <S.Button onClick={() => navigate('/sign-up')}>회원가입</S.Button>
+      </S.Inner>
     </S.Container>
   );
 };

--- a/src/pages/Entry/Index.jsx
+++ b/src/pages/Entry/Index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import * as S from './style';
+
+const Entry = () => {
+  const navigate = useNavigate();
+  return (
+    <S.Container>
+      <S.Title>서비스 페이지입니다</S.Title>
+      <S.Button onClick={() => navigate('/sign-in')}>로그인</S.Button>
+      <S.Button onClick={() => navigate('/sign-up')}>회원가입</S.Button>
+    </S.Container>
+  );
+};
+
+export default Entry;

--- a/src/pages/Entry/style.js
+++ b/src/pages/Entry/style.js
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+export const Container = styled.form`
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  height: 100vh;
+  border: 2px solid red;
+  ${({ theme }) => theme.common.flexCenter};
+  /* margin-top: 40vh; */
+`;
+
+export const Inner = styled.div`
+  ${({ theme }) => theme.common.flexColumnStart};
+  border: 2px solid black;
+  width: 100%;
+`;
+
+export const Title = styled.div`
+  color: ${({ theme }) => theme.palette.primary};
+  font-size: ${({ theme }) => theme.fontSizes.title};
+`;
+
+export const ItemContainer = styled.div`
+  width: 80%;
+`;
+
+export const Button = styled.button`
+  margin: 1rem 1rem 2rem 0rem;
+  padding: 0.5rem;
+  box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
+  border-radius: 0.6rem;
+  border: none;
+  color: ${({ theme }) => theme.palette.primary};
+  background-color: ${({ theme }) => theme.palette.white};
+  font-size: ${({ theme }) => theme.fontSizes.buttonText};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  width: 30%;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.palette.primaryLight};
+  }
+  &:focus {
+    background-color: ${({ theme }) => theme.palette.primary};
+    color: ${({ theme }) => theme.palette.white};
+  }
+`;

--- a/src/pages/SignIn/style.js
+++ b/src/pages/SignIn/style.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Form from 'react-bootstrap/Form';
+
 export const FormContainer = styled.form`
   ${({ theme }) => theme.common.flexColumnStart};
   font-weight: ${({ theme }) => theme.fontWeight.bold};

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 
 // pages
 import SignUp from '~/pages/SignUp';
@@ -11,19 +11,57 @@ import CustomProducts from '~/pages/CustomProducts';
 import WishProducts from '~/pages/WishProducts';
 import Cart from '~/pages/Cart';
 import Layout from '../pages/Layout';
+import Entry from '../pages/Entry/Index';
+import PrivateRoute from './PrivateRoute';
 const AppRouter = () => {
   return (
     <div>
       <Routes>
         <Route element={<Layout />}>
-          <Route path='/' element={<AllProducts />} />
-          <Route path='custom-products' element={<CustomProducts />} />
-          <Route path='all-products' element={<AllProducts />} />
-          <Route path='wish-products' element={<WishProducts />} />
-          <Route path='cart' element={<Cart />} />
-          <Route path='my-page' element={<MyPage />} />
+          <Route
+            path='/'
+            element={
+              <PrivateRoute>
+                <AllProducts />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path='custom-products'
+            element={
+              <PrivateRoute>
+                <CustomProducts />
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path='wish-products'
+            element={
+              <PrivateRoute>
+                <WishProducts />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path='cart'
+            element={
+              <PrivateRoute>
+                <Cart />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path='my-page'
+            element={
+              <PrivateRoute>
+                <MyPage />
+              </PrivateRoute>
+            }
+          />
         </Route>
 
+        <Route path='entry' element={<Entry />} />
         <Route path='sign-up' element={<SignUp />} />
         <Route path='sign-in' element={<SignIn />} />
       </Routes>

--- a/src/routes/PrivateRoute/index.jsx
+++ b/src/routes/PrivateRoute/index.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { Route, Navigate } from 'react-router-dom';
+import { useGetPersonQuery } from '~/api/customApi';
+import Loading from '../../components/ui/Loading';
+
+const PrivateRoute = ({ children }) => {
+  const { data: isTokenValid, isLoading, isError } = useGetPersonQuery();
+
+  useEffect(() => console.log('토큰유효성', isTokenValid), [isTokenValid]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    console.log('토큰이 유효하지 않음');
+
+    alert('로그인이 필요합니다!');
+    return <Navigate to='/entry' />;
+  }
+
+  // if (isTokenValid) {
+  //   return children;
+  // }
+
+  return children;
+};
+
+export default PrivateRoute;


### PR DESCRIPTION
## <img src='https://emojis.slackmojis.com/emojis/images/1643514558/5570/confused_dog.gif?1643514558' alt='개요' width=30px> 개요
로그인되지 않은 경우 로그인/회원가입 페이지로 리다이렉트하는 기능 구현

## <img src='https://emojis.slackmojis.com/emojis/images/1643514738/7421/typingcat.gif?1643514738' alt='작업 사항' width=30px> 작업 사항
feat
- [x] 로그인 여부에 따라 진입페이지로 리다이렉트

design
- [x] 서비스 페이지 스타일링

## <img src='https://slackmojis.com/emojis/9116-excuseme/download' alt='리뷰어에게' width=30px> 리뷰어에게

처음에는 <Route ~~ /> 컴포넌트를 리턴하는 PrivateRoute라는 이름의 컴포넌트를 <Routes/> 안쪽에 작성했더니 Routes 안에는 Route 또는 React.fragment만 작성할 수 있다며 오류가 발생했었습니다.

그래서 이 오류를 해결하기 위해 Route의 element에 PrivateRoute를 추가하고 PrivateRoute의 children으로 path에 해당하는 컴포넌트를 삽입하는 우회적인 방법을 사용했는데요.

현업에서는 이런 내비게이션 가드 기능을 어떻게 구현하시는지 궁금합니다

## 이슈 번호
Entry/#69
